### PR TITLE
test function definition validation in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 export PATH := $(MYGOBIN):$(PATH)
 
 # Run all tests in this repo for in-tree and out-of-tree functions
-all: install-tools license verify-metadata test-in-tree
+all: install-tools license validate-metadata test-in-tree
 
 ## Run all unit tests and e2e tests for in-tree functions
 test-in-tree: e2e-test unit-test lint
@@ -18,7 +18,12 @@ test-in-tree: e2e-test unit-test lint
 # Run all the e2e tests for in-tree functions
 e2e-test: build-local $(MYGOBIN)/kustomize
 	cd tests; \
-    go test -v ./...
+    go test -v -run TestExamples
+    
+# Validate the metadata for all published functions
+validate-metadata:
+	cd tests; \
+    go test -v -run TestValidateMetadata
 
 # Run all unit tests for in-tree functions
 unit-test:
@@ -37,10 +42,6 @@ license: $(MYGOBIN)/addlicense
 lint:
 	cd tests; golangci-lint run ./...
 	cd krm-functions && find . -type f -name go.mod -execdir golangci-lint run ./... \;
-
-# TODO
-# Verify the metadata for all in-tree and out-of-tree functions
-verify-metadata:
 
 # Install tools needed to run tests
 install-tools: \

--- a/publishers/sig-cli/catalogs/v20220225.yaml
+++ b/publishers/sig-cli/catalogs/v20220225.yaml
@@ -1,1 +1,15 @@
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This file is just a placeholder until we have a published catalog.

--- a/publishers/sig-cli/functions/render-helm-chart.yaml
+++ b/publishers/sig-cli/functions/render-helm-chart.yaml
@@ -23,7 +23,7 @@ spec:
   names:
     kind: RenderHelmChart
   versions:
-    name: v1
+  - name: v1
     idempotent: true
     license: Apache 2.0
     maintainers:
@@ -70,58 +70,58 @@ spec:
             items:
               type: object
               description: parameters to configure the helm chart rendering.
-                properties:
-                  chartArgs:
-                    description: arguments that describe the chart being rendered.
-                    type: object
+              properties:
+                chartArgs:
+                  description: arguments that describe the chart being rendered.
+                  type: object
+                  properties:
+                    name:
+                      description: the name of the chart.
+                      type: string
+                    version:
+                      description: the version of the chart.
+                      type: string
+                    repo:
+                      description: URL locating the chart on the internet
+                      type: string
+                templateOptions:
+                  description: a collection of fields that map to flag options of `helm template`.
+                  type: object
+                  properties:
+                    apiVersions:
+                      description: kubernetes api versions used for Capabilities.APIVersions
+                      type: array
+                      items:
+                        type: string
+                    releaseName:
+                      description: replaces RELEASE_NAME in the chart template output
+                      type: string
+                    namespace:
+                      description: sets the target namespace for a release (`.Release.Namespace` in the template)
+                      type: string
+                    nameTemplate:
+                      description: specifies the template used to name the release
+                      type: string
+                    includeCRDs:
+                      description: specifies if Helm should also generate CustomResourceDefinitions. Legal values are "true", "false" (default).
+                      type: bool
+                    skipTests:
+                      description: if set, skip tests from templated output. Legal values are "true", "false" (default).
+                      type: bool
+                    values:
+                      description: values to use instead of the default values that accompany the chart.
+                      type: object
                       properties:
-                        name:
-                          description: the name of the chart.
-                          type: string
-                        version:
-                          description: the version of the chart.
-                          type: string
-                        repo:
-                          description: URL locating the chart on the internet
-                          type: string
-                  templateOptions:
-                    description: a collection of fields that map to flag options of `helm template`.
-                    type: object
-                      properties:
-                        apiVersions:
-                          description: kubernetes api versions used for Capabilities.APIVersions
+                        valuesFiles:
+                          description: remote or local filepaths to use instead of the default values that accompanied the chart. The default values are in '{chartHome}/{name}/values.yaml', where `chartHome` and `name` are the parameters defined above.
                           type: array
                           items:
                             type: string
-                        releaseName:
-                          description: replaces RELEASE_NAME in the chart template output
-                          type: string
-                        namespace: string
-                          description:
-                          type: string
-                        nameTemplate:
-                          description: sets the target namespace for a release (`.Release.Namespace` in the template)
-                          type: string
-                        includeCRDs:
-                          description: specifies if Helm should also generate CustomResourceDefinitions. Legal values are "true", "false" (default).
-                          type: bool
-                        skipTests:
-                          description: if set, skip tests from templated output. Legal values are "true", "false" (default).
-                          type: bool
-                        values:
-                          description: values to use instead of the default values that accompany the chart.
+                        valuesInline:
+                          description: values defined inline to use instead of default values that accompany the chart.
                           type: object
-                          properties:
-                            valuesFiles:
-                              description: remote or local filepaths to use instead of the default values that accompanied the chart. The default values are in '{chartHome}/{name}/values.yaml', where `chartHome` and `name` are the parameters defined above.
-                              type: array
-                              items:
-                                type: string
-                            valuesInline:
-                              description: values defined inline to use instead of default values that accompany the chart.
-                              type: object
-                              additionalProperties:
-                                type: string
-                            valuesMerge:
-                              description: valuesMerge specifies how to treat ValuesInline with respect to ValuesFiles. Legal values are 'merge', 'override' (default), 'replace'.
-                              type: string
+                          additionalProperties:
+                            type: string
+                        valuesMerge:
+                          description: valuesMerge specifies how to treat ValuesInline with respect to ValuesFiles. Legal values are 'merge', 'override' (default), 'replace'.
+                          type: string

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -2,11 +2,18 @@ module sigs.k8s.io/krm-functions-registry/tests
 
 go 1.17
 
-require github.com/GoogleContainerTools/kpt v1.0.0-beta.13.0.20220208222711-5169954be82f
+require (
+	github.com/GoogleContainerTools/kpt v1.0.0-beta.13.0.20220208222711-5169954be82f
+	github.com/stretchr/testify v1.7.0
+	k8s.io/kube-openapi v0.0.0-20211109043139-026bd182f079
+	sigs.k8s.io/kustomize/kyaml v0.13.3
+	sigs.k8s.io/yaml v1.2.0
+)
 
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-errors/errors v1.4.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
@@ -15,9 +22,16 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20211109043139-026bd182f079 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.3 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e // indirect
 )
+
+replace sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.13.4-0.20220224183231-6950a0d24640

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -68,6 +68,7 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -200,6 +201,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -238,10 +240,12 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
+github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -278,6 +282,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/igorsobreira/titlecase v0.0.0-20140109233139-4156b5b858ac/go.mod h1:KOzUkqpWM2xArNm82cehGc5PBFYV1Qadzzt81aJi7F0=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -332,6 +337,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
@@ -339,6 +345,7 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -375,6 +382,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f/go.mod h1:/iRjX3DdSK956SzsUdV55J+wIsQ+2IBWmBrB4RvZfk4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -408,6 +416,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -427,11 +436,13 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
+github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
@@ -440,6 +451,7 @@ github.com/spyzhov/ajson v0.4.2/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzy
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -453,6 +465,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -860,6 +873,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -925,6 +939,7 @@ k8s.io/kubectl v0.22.2/go.mod h1:BApg2j0edxLArCOfO0ievI27EeTQqBDMNU9VQH734iQ=
 k8s.io/metrics v0.22.2/go.mod h1:GUcsBtpsqQD1tKFS/2wCKu4ZBowwRncLOJH1rgWs3uw=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e h1:ldQh+neBabomh7+89dTpiFAB8tGdfVmuIzAHbvtl+9I=
 k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
@@ -936,10 +951,8 @@ sigs.k8s.io/kustomize/api v0.8.11/go.mod h1:a77Ls36JdfCWojpUqR6m60pdGY1AYFix4AH8
 sigs.k8s.io/kustomize/api v0.11.1/go.mod h1:GZuhith5YcqxIDe0GnRJNx5xxPTjlwaLTt/e+ChUtJA=
 sigs.k8s.io/kustomize/cmd/config v0.9.13/go.mod h1:7547FLF8W/lTaDf0BDqFTbZxM9zqwEJqCKN9sSR0xSs=
 sigs.k8s.io/kustomize/kustomize/v4 v4.2.0/go.mod h1:MOkR6fmhwG7hEDRXBYELTi5GSFcLwfqwzTRHW3kv5go=
-sigs.k8s.io/kustomize/kyaml v0.11.0/go.mod h1:GNMwjim4Ypgp/MueD3zXHLRJEjz7RvtPae0AwlvEMFM=
-sigs.k8s.io/kustomize/kyaml v0.12.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
-sigs.k8s.io/kustomize/kyaml v0.13.3 h1:tNNQIC+8cc+aXFTVg+RtQAOsjwUdYBZRAgYOVI3RBc4=
-sigs.k8s.io/kustomize/kyaml v0.13.3/go.mod h1:/ya3Gk4diiQzlE4mBh7wykyLRFZNvqlbh+JnwQ9Vhrc=
+sigs.k8s.io/kustomize/kyaml v0.13.4-0.20220224183231-6950a0d24640 h1:PaLEJWNK0yh54TSCmEtaDvzxKbYwqY3RfoTugbaQTKM=
+sigs.k8s.io/kustomize/kyaml v0.13.4-0.20220224183231-6950a0d24640/go.mod h1:/ya3Gk4diiQzlE4mBh7wykyLRFZNvqlbh+JnwQ9Vhrc=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=

--- a/tests/testutils.go
+++ b/tests/testutils.go
@@ -1,0 +1,216 @@
+// Copyright 2022 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+const KrmFunctionSchema = `swagger: "2.0"
+info:
+  title: KRM Function Metadata
+  version: v1alpha1
+definitions:
+  KRMFunctionDefinition:
+    type: object
+    description: |
+      KRMFunctionDefinition is metadata that defines a KRM function
+      the same way a CustomResourceDefinition defines a custom resource.
+    x-kubernetes-group-version-kind:
+      - group: config.kubernetes.io
+        kind: KRMFunctionDefinition
+        version: v1alpha1
+    required:
+      - apiVersion
+      - kind
+      - spec
+    properties:
+      apiVersion:
+        description: apiVersion of KRMFunctionDefinition. i.e. config.kubernetes.io/v1alpha1
+        type: string
+        enum:
+          - config.kubernetes.io/v1alpha1
+      kind:
+        description: kind of the KRMFunctionDefinition. It must be KRMFunctionDefinition.
+        type: string
+        enum:
+          - KRMFunctionDefinition
+      spec:
+        type: object
+        description: spec contains the metadata for a KRM function.
+        required:
+          - group
+          - names
+          - description
+          - publisher
+          - versions
+        properties:
+          group:
+            description: group of the functionConfig
+            type: string
+          description:
+            description: brief description of the KRM function.
+            type: string
+          publisher:
+            description: the entity (e.g. organization) that produced and owns this KRM function.
+            type: string
+          names:
+            description: the resource and kind names for the KRM function
+            type: object
+            required:
+            - kind
+            properties:
+              kind:
+                description: the Kind of the functionConfig
+                type: string
+          versions:
+            description: the versions of the functionConfig
+            type: array
+            items:
+              type: object
+              required:
+                - name
+                - schema
+                - idempotent
+                - runtime
+                - usage
+                - examples
+                - license
+              properties:
+                name:
+                  description: Version of the functionConfig
+                  type: string
+                schema:
+                  description: a URI pointing to the schema of the functionConfig
+                  type: object
+                  required:
+                    - openAPIV3Schema
+                  properties:
+                    openAPIV3Schema:
+                      description: openAPIV3Schema is the OpenAPI v3 schema to use for validation
+                      # kube-openapi validation doesn't support references, and inlining this ref is extremely tedious
+                      # $ref: "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+                idempotent:
+                  description: If the function is idempotent.
+                  type: boolean
+                usage:
+                  description: |
+                    A URI pointing to a README.md that describe the details of how to
+                    use the KRM function. It should at least cover what the function
+                    does and what functionConfig does it support and it should give
+                    detailed explanation about each field in the functionConfig.
+                  type: string
+                examples:
+                  description: |
+                    A list of URIs that point to README.md files. At least one example
+                    must be provided. Each README.md should cover an example. It
+                    should at least cover how to get input resources, how to run it
+                    and what is the expected output.
+                  type: array
+                  items:
+                    type: string
+                license:
+                  description: The license of the KRM function.
+                  type: string
+                  enum:
+                    - Apache 2.0
+                maintainers:
+                  description: |
+                    The maintainers for the function. It should only be used
+                    when the maintainers are different from the ones in
+                    spec.maintainers. When this field is specified, it
+                    override spec.maintainers.
+                  type: array
+                  items:
+                    type: string
+                runtime:
+                  description: |
+                    The runtime information about the KRM function. At least one of
+                    container and exec must be set.
+                  type: object
+                  properties:
+                    container:
+                      description: The runtime information for container-based KRM function.
+                      type: object
+                      required:
+                        - image
+                      properties:
+                        image:
+                          description: The image name of the KRM function.
+                          type: string
+                        sha256:
+                          description: |
+                            The digest of the image that can be verified against. It
+                            is required only when the image is using semver.
+                          type: string
+                        requireNetwork:
+                          description: If network is required to run this function.
+                          type: boolean
+                        requireStorageMount:
+                          description: If storage mount is required to run this function.
+                          type: boolean
+                    exec:
+                      description: The runtime information for exec-based KRM function.
+                      type: object
+                      required:
+                        - platform
+                      properties:
+                        platforms:
+                          description: Per platform runtime information.
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - bin
+                              - os
+                              - arch
+                              - uri
+                              - sha256
+                            properties:
+                              bin:
+                                description: The binary name.
+                                type: string
+                              os:
+                                description: The target operating system to run the KRM function.
+                                type: string
+                                enum:
+                                  - linux
+                                  - darwin
+                                  - windows
+                              arch:
+                                description: The target architecture to run the KRM function.
+                                type: string
+                                enum:
+                                  - amd64
+                                  - arm64
+                              uri:
+                                description: The location to download the binary.
+                                type: string
+                              sha256:
+                                description: The degist of the binary that can be used to verify the binary.
+                                type: string
+          home:
+            description: A URI pointing the home page of the KRM function.
+            type: string
+          maintainers:
+            description: The maintainers for the function.
+            type: array
+            items:
+              type: string
+          tags:
+            description: |
+              The tags (or keywords) of the function. e.g. mutator, validator,
+              generator, prefix, GCP.
+            type: array
+            items:
+              type: string
+paths: {}
+`

--- a/tests/validate-metadata_test.go
+++ b/tests/validate-metadata_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"k8s.io/kube-openapi/pkg/validation/strfmt"
+	"k8s.io/kube-openapi/pkg/validation/validate"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	k8syaml "sigs.k8s.io/yaml"
+)
+
+// TestValidateMetadata validates that the function metadata in each function metadata
+// file of the publishers directory is a valid KRMFunctionDefinition.
+func TestValidateMetadata(t *testing.T) {
+	assert.NoError(t, os.Chdir("../publishers"))
+	publishers, err := os.ReadDir(".")
+	assert.NoError(t, err)
+
+	for _, publisher := range publishers {
+		if publisher.IsDir() {
+			functionDir := filepath.Join(publisher.Name(), "functions")
+			functions, err := os.ReadDir(functionDir)
+			assert.NoError(t, err)
+
+			for _, function := range functions {
+				validateFunctionMetadata(t, filepath.Join(functionDir, function.Name()))
+			}
+		}
+	}
+}
+
+func validateFunctionMetadata(t *testing.T, path string) {
+	functionMetadata, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	schemaJSON, err := k8syaml.YAMLToJSON([]byte(KrmFunctionSchema))
+	require.NoError(t, err)
+
+	swagger := &spec.Swagger{}
+	require.NoError(t, swagger.UnmarshalJSON(schemaJSON))
+
+	var input map[string]interface{}
+	inputJSON, err := k8syaml.YAMLToJSON(functionMetadata)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(inputJSON, &input))
+
+	schema := swagger.Definitions["KRMFunctionDefinition"]
+	schemaValidationError := validate.AgainstSchema(&schema,
+		input, strfmt.Default)
+
+	require.NoError(t, schemaValidationError)
+
+	var def framework.KRMFunctionDefinition
+	err = k8syaml.Unmarshal(functionMetadata, &def)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Recreating https://github.com/kubernetes-sigs/krm-functions-registry/pull/8 because the rebase made some things weird

This adds a CI check to validate the KRM function metadata based on the openapi schema of KRMFunctionDefinition as defined in the Catalog KEP. I can confirm that it works because it caught some of my mistakes in defining the render-helm-chart function definition 

/cc @KnVerey
/cc @jeremyrickard
/cc @mengqiy

